### PR TITLE
Save button visibility in profile page

### DIFF
--- a/src/pages/profilePage.jsx
+++ b/src/pages/profilePage.jsx
@@ -208,7 +208,7 @@ export default function Profile(props){
                             <>
                                 
                                 <Button colorScheme="gray" leftIcon={<FontAwesomeIcon icon={faEdit}/>} onClick={()=>setEdit(true)}>Edit</Button>
-                                <Button colorScheme="blue" onClick={saveData}>Save</Button>
+                                {edit &&<Button colorScheme="blue" onClick={saveData}>Save</Button>}
                                 <Button colorScheme="gray" variant="solid" onClick = {share} leftIcon={<FontAwesomeIcon icon={faShareAlt}/>}>Share</Button>
 
                             </>


### PR DESCRIPTION
# Pull Request Template

## Description

Now the "Save" button is visible only when in edit mode and not while just viewing the profile. 

Fixes #45 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

<img width="960" alt="Screenshot 2022-04-24 201831" src="https://user-images.githubusercontent.com/72207545/164982601-4cb902df-a317-41c7-b01b-88e00f0d1000.png">

