### PR TITLE
add pages corresponding to password reset option

### DIFF
--- a/public/icons/done-icon.svg
+++ b/public/icons/done-icon.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?><svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 122.88 122.88" style="enable-background:new 0 0 122.88 122.88" xml:space="preserve"><style type="text/css"><![CDATA[
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#3AAF3C;}
+]]></style><g><path class="st0" d="M61.44,0c33.93,0,61.44,27.51,61.44,61.44c0,33.93-27.51,61.44-61.44,61.44C27.51,122.88,0,95.37,0,61.44 C0,27.51,27.51,0,61.44,0L61.44,0L61.44,0z M39.48,56.79c4.6,2.65,7.59,4.85,11.16,8.78c9.24-14.88,19.28-23.12,32.32-34.83 l1.28-0.49h14.28C79.38,51.51,64.53,69.04,51.24,94.68c-6.92-14.79-13.09-25-26.88-34.47L39.48,56.79L39.48,56.79z"/></g></svg>

--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,8 @@ import Contact from "./pages/contact";
 import PollResults from './pages/pollResults';
 import Discover from './pages/discover';
 import Homepage from './pages/homePage';
+import ForgotPassEmail from './pages/ForgotPassEmail';
+import EmailSentPage from './pages/emailSent';
 import {TransitionGroup, CSSTransition} from 'react-transition-group';
 
 function App() {
@@ -57,6 +59,10 @@ function App() {
 
                       {/* Change to /dynamic by a poll id */}
                       <Route path = "/poll/:id" component = {PollResults}/>
+		      
+		      {/* Forgot Password */}
+		      <Route path = "/forgot-password" component = {ForgotPassEmail}/>
+		      <Route path = "/email-sent" component = {EmailSentPage}/>
 
                       {/* NOT FOUND */}
                       <Route component = {NotFound}/>

--- a/src/components/emailRequestForm.jsx
+++ b/src/components/emailRequestForm.jsx
@@ -1,0 +1,29 @@
+import { Button, FormControl, FormLabel, Input, Stack, Link} from '@chakra-ui/react'
+import { useHistory} from 'react-router-dom';
+import * as React from 'react'
+
+
+function EmailRequestForm(props) {
+	const history = useHistory();
+	function handleSubmit(event) {
+		event.preventDefault();
+		props.handleResetPassword();
+		history.push("/email-sent");
+	}
+		
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack spacing="6">
+	<FormControl id="email"  >
+	  <FormLabel>Email address</FormLabel>
+	  <Input name="email" type="email" autoComplete="email" required />
+	</FormControl>
+	<Button type="submit" colorScheme="blue" size="lg" fontSize="md" >
+	 Send Password Reset Link
+	</Button>
+      </Stack>
+    </form>
+  )
+}
+
+export default EmailRequestForm;

--- a/src/pages/ForgotPassEmail.jsx
+++ b/src/pages/ForgotPassEmail.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import initFirebase from '../lib/firebase';
+import firebase from 'firebase/app';
+import 'firebase/auth';
+import { useAuth } from '../lib/auth';
+import { addDoc, getDoc } from '../lib/db';
+
+import { DividerWithText } from '../components/dividerWithText';
+import { FaGoogle } from 'react-icons/fa';
+
+import {
+  Container,
+  Box,
+  Heading,
+  Text,
+  Button,
+  SimpleGrid,
+  useColorModeValue as mode,
+  VisuallyHidden,
+  useToast,
+} from '@chakra-ui/react';
+import EmailRequestForm from '../components/emailRequestForm';
+
+function ForgotPassEmail() {
+	function handleResetPassword() {
+	}
+	return (
+		
+<Container maxW="container.sm" p={8}>
+      <Box bg={mode('gray.50', 'inherit')} minH="100vh" py="12" px={{ sm: '6', lg: '8' }}>
+        <Box maxW={{ sm: 'md' }} mx={{ sm: 'auto' }} w={{ sm: 'full' }}>
+          <Heading mt="6" textAlign="center" size="xl" fontWeight="extrabold">
+           Password Reset 
+          </Heading>
+          <Text mt="4" align="center" maxW="md" fontWeight="medium">
+            <span>Enter the Email associated with your account </span>
+                      </Text>
+        </Box>
+        <Box maxW={{ sm: 'md' }} mx={{ sm: 'auto' }} mt="8" w={{ sm: 'full' }}>
+          <Box
+            bg={mode('white', 'gray.700')}
+            py="8"
+            px={{ base: '4', md: '10' }}
+            shadow="base"
+            rounded={{ sm: 'lg' }}
+          >
+            <EmailRequestForm handleResetPassword={handleResetPassword} />
+          </Box>
+        </Box>
+      </Box>
+    </Container>
+
+	)
+}
+
+export default ForgotPassEmail;

--- a/src/pages/emailSent.jsx
+++ b/src/pages/emailSent.jsx
@@ -21,6 +21,8 @@ import {
   useColorModeValue as mode,
   VisuallyHidden,
   useToast,
+  Image,
+  Center
 } from '@chakra-ui/react';
 import Link from '../components/link';
 import EmailRequestForm from '../components/emailRequestForm';
@@ -40,10 +42,10 @@ function EmailSentPage() {
           <Heading mt="6" textAlign="center" size="xl" fontWeight="extrabold">
            Password Reset 
           </Heading>
-          <Text mt="4" align="center" maxW="md" fontWeight="medium">
-            <span>Enter the Email associated with your account </span>
-                      </Text>
         </Box>
+	<Center>
+		<Image src="./icons/done-icon.svg" alt="logo" boxSize="20vh" my="4" />
+	</Center>
         <Box maxW={{ sm: 'md' }} mx={{ sm: 'auto' }} mt="8" w={{ sm: 'full' }}>
           <Box
             bg={mode('white', 'gray.700')}

--- a/src/pages/emailSent.jsx
+++ b/src/pages/emailSent.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useHistory, Route , Routes , Redirect } from 'react-router-dom';
+
+import initFirebase from '../lib/firebase';
+import firebase from 'firebase/app';
+import 'firebase/auth';
+import { useAuth } from '../lib/auth';
+import { addDoc, getDoc } from '../lib/db';
+
+import { emailRequestForm } from "../components/emailRequestForm";
+import { DividerWithText } from '../components/dividerWithText';
+import { FaGoogle } from 'react-icons/fa';
+
+import {
+  Container,
+  Box,
+  Heading,
+  Text,
+  Button,
+  SimpleGrid,
+  useColorModeValue as mode,
+  VisuallyHidden,
+  useToast,
+} from '@chakra-ui/react';
+import Link from '../components/link';
+import EmailRequestForm from '../components/emailRequestForm';
+import {LoginForm} from '../components/loginForm';
+import login from './login';
+
+function EmailSentPage() {
+	function handleResetPassword() {
+		console.log("reset password");
+		window.location.href = "/emailSent";
+	}
+	return (
+<Container >
+		
+      <Box bg={mode('gray.50', 'inherit')} minH="100vh" py="12" px={{ sm: '6', lg: '8' }}>
+        <Box maxW={{ sm: 'md' }} mx={{ sm: 'auto' }} w={{ sm: 'full' }}>
+          <Heading mt="6" textAlign="center" size="xl" fontWeight="extrabold">
+           Password Reset 
+          </Heading>
+          <Text mt="4" align="center" maxW="md" fontWeight="medium">
+            <span>Enter the Email associated with your account </span>
+                      </Text>
+        </Box>
+        <Box maxW={{ sm: 'md' }} mx={{ sm: 'auto' }} mt="8" w={{ sm: 'full' }}>
+          <Box
+            bg={mode('white', 'gray.700')}
+            py="8"
+            px={{ base: '4', md: '10' }}
+            shadow="base"
+            rounded={{ sm: 'lg' }}
+          >
+            <Text align="center" maxW="md" fontWeight="medium"> A email with password reset link has been sent </Text>
+          </Box>
+        </Box>
+      </Box>
+    </Container>
+	)
+}
+
+export default EmailSentPage;


### PR DESCRIPTION

![Screenshot from 2023-05-24 09-58-41](https://github.com/agamjotsingh18/pollitup/assets/109089135/7312f754-97d4-4ced-8814-591363841af5)

![Screenshot from 2023-05-24 09-58-57](https://github.com/agamjotsingh18/pollitup/assets/109089135/94b4e86e-7aac-4049-96a3-6c384d1c372e)

## Description

Added two new pages for the Forget Password feature 
1. Page to request email
2. Confirmation page to notify user of the email
 
Also, added the corresponding routes inside the App.js

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Future Scope 

1. Some contextual improvements to be made
2. Implement firebase to complete the password reset process