### PR TITLE
Add Share Poll via Link Feature

### DIFF
--- a/src/components/poll.jsx
+++ b/src/components/poll.jsx
@@ -21,13 +21,13 @@ export default function Poll(props) {
 
     const toast = useToast();
 
-    function upVote() {
-        if (hasVoted==='down') {
+    function upVote(){
+        if (hasVoted==='down'){
             setVotes(votes+2);
             setVoted('up');
         }
         else if (hasVoted === '') {
-            setVotes(votes+1);
+            setVotes(votes + 1);
             setVoted('up');
         }
         else {

--- a/src/components/poll.jsx
+++ b/src/components/poll.jsx
@@ -13,6 +13,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCopy, faCheck } from '@fortawesome/free-solid-svg-icons'
 
 export default function Poll(props) {
+    
     const [showModal, setShowModal] = React.useState(false);
     const [votes, setVotes] = React.useState(Math.floor(Math.random() * 5)); //replce with prop
     const [hasVoted, setVoted] = React.useState('');
@@ -21,12 +22,12 @@ export default function Poll(props) {
     const toast = useToast();
 
     function upVote() {
-        if (hasVoted === 'down') {
-            setVotes(votes + 2);
+        if (hasVoted==='down') {
+            setVotes(votes+2);
             setVoted('up');
         }
         else if (hasVoted === '') {
-            setVotes(votes + 1);
+            setVotes(votes+1);
             setVoted('up');
         }
         else {
@@ -102,8 +103,7 @@ export default function Poll(props) {
                     </Center>
                 </Flex>
                 {(props.flag === "discover") ? <Button colorScheme="green" onClick={() => setShowModal(true)} isFullWidth={true}>Open Poll</Button> :
-                    <>
-                        <Button colorScheme="green" onClick={() => setShowModal(true)} isFullWidth={true}>Open Poll</Button>
+                    <><Button colorScheme="green" onClick={() => setShowModal(true)} isFullWidth={true}>Open Poll</Button>
                         <Button colorScheme="red" onClick={() => deleteHandler(props.id)} isFullWidth={true}>Delete Poll</Button>
                     </>}
             </Stack>

--- a/src/components/poll.jsx
+++ b/src/components/poll.jsx
@@ -13,7 +13,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCopy, faCheck } from '@fortawesome/free-solid-svg-icons'
 
 export default function Poll(props) {
-    
+
     const [showModal, setShowModal] = React.useState(false);
     const [votes, setVotes] = React.useState(Math.floor(Math.random() * 5)); //replce with prop
     const [hasVoted, setVoted] = React.useState('');

--- a/src/components/poll.jsx
+++ b/src/components/poll.jsx
@@ -9,18 +9,20 @@ import { deleteDoc } from '../lib/db';
 import { useToast } from "@chakra-ui/react";
 
 import Pollpopup from './pollPopup';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCopy, faCheck } from '@fortawesome/free-solid-svg-icons'
 
 export default function Poll(props) {
-
     const [showModal, setShowModal] = React.useState(false);
     const [votes, setVotes] = React.useState(Math.floor(Math.random() * 5)); //replce with prop
     const [hasVoted, setVoted] = React.useState('');
+    const [copyIcon, setCopyIcon] = React.useState(faCopy);
 
     const toast = useToast();
 
-    function upVote(){
-        if (hasVoted==='down'){
-            setVotes(votes+2);
+    function upVote() {
+        if (hasVoted === 'down') {
+            setVotes(votes + 2);
             setVoted('up');
         }
         else if (hasVoted === '') {
@@ -61,6 +63,23 @@ export default function Poll(props) {
         });
     }
 
+    async function shareHandler(docId) {
+        const loc = window.location;
+        console.log(loc.port);
+        setCopyIcon(faCheck);
+        toast({
+            title: "Copy",
+            description: "Copied to Clipboard",
+            status: "success",
+            duration: 1000,
+            isClosable: true,
+        });
+        setTimeout(() => {
+            setCopyIcon(faCopy);
+        }, 1000);
+        await navigator.clipboard.writeText(loc.host + "/poll" + "/" + docId);
+    }
+
     return (
         <Box px={8} py={{ base: 12, lg: 8 }} borderWidth="1px" borderRadius="lg" overflow="hidden">
             <Stack direction="column" spacing={4}>
@@ -72,15 +91,19 @@ export default function Poll(props) {
                             <ChevronDownIcon onClick={downVote} color={hasVoted === "down" && "red"} />
                         </Stack>
                     }
-                    <Center flex={1}>
+                    <Center flex={1} justifyContent={"space-between"}>
                         <Box align="left">
                             <Heading as="h6" size="md">{props.name}</Heading>
                             <Text>{props.description}</Text>
                         </Box>
+                        <Button cursor={"pointer"} colorScheme="whatsapp" rounded={"full"} onClick={() => shareHandler(props.id)} title='Copy Link'>
+                            <FontAwesomeIcon icon={copyIcon} />
+                        </Button>
                     </Center>
                 </Flex>
                 {(props.flag === "discover") ? <Button colorScheme="green" onClick={() => setShowModal(true)} isFullWidth={true}>Open Poll</Button> :
-                    <><Button colorScheme="green" onClick={() => setShowModal(true)} isFullWidth={true}>Open Poll</Button>
+                    <>
+                        <Button colorScheme="green" onClick={() => setShowModal(true)} isFullWidth={true}>Open Poll</Button>
                         <Button colorScheme="red" onClick={() => deleteHandler(props.id)} isFullWidth={true}>Delete Poll</Button>
                     </>}
             </Stack>

--- a/src/components/pollPopup.jsx
+++ b/src/components/pollPopup.jsx
@@ -39,6 +39,7 @@ export default function PollPopup(props){
     function handleClose(){
         props.set(false);
         setOpen(false);
+        props.setVoted(true);
     }
 
     function handleClick(e){
@@ -117,7 +118,7 @@ export default function PollPopup(props){
             </ModalBody>
 
                 <ModalFooter>
-                    { canViewPollResults && <Link to={`poll/${props.data.id}`} ><Button colorScheme="green" mr={3} onClick={handleClose}>
+                    { canViewPollResults && props.fromPollResults !== true && <Link to={`poll/${props.data.id}`} ><Button colorScheme="green" mr={3} onClick={handleClose}>
                         View Poll Results
                     </Button></Link>}
                     <Button colorScheme="blue" mr={3} onClick={handleSubmit}>


### PR DESCRIPTION
## Description
This PR adds a share poll via link feature.
- I have added a `Copy Link` option for each poll to copy the link. Link is of the route `/poll/:id`.
- I have modified the poll results page for the non-owners to view the `Submit your response` button when visiting the page through above copied link.
- Also, until you do not submit a response, responses will not be visible to the user under the `Responses` section.
- When the user clicks on the `Submit your Response`, the `PollPopup` modal opens but no `View Poll Results` appears as we are on the same page.

Fixes #161 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
