### PR TITLE
Fixed the issue on the poll info page with the Author profile link, closes #253

### DIFF
--- a/src/pages/profilePage.jsx
+++ b/src/pages/profilePage.jsx
@@ -66,7 +66,7 @@ export default function Profile(props) {
         checkUserDoc();
 
         async function getPolls() {
-            const userDocs = await getUserDocs('polls', user.uid);
+            const userDocs = await getUserDocs('polls', uid? uid : user.uid);
             setPolls(userDocs);
             // setDisplayName(user.displayName ? user.displayName : "");
             setUserDoc(user)

--- a/src/pages/profilePage.jsx
+++ b/src/pages/profilePage.jsx
@@ -52,7 +52,7 @@ export default function Profile(props) {
         if (!user) return;
 
         async function checkUserDoc() {
-            const userDatas = await getDoc('users', user.uid);
+            const userDatas = await getDoc('users', uid? uid : user.uid);
             if (!userDatas) {
                 await addDoc('users', {
                     displayName: "",


### PR DESCRIPTION

## Description

Now when user will click on Author(Click to view profile) on the Poll info page, it will get redirected to the profile of the author rather than user's own profile.


Fixes #253 

## Type of change
Change in the implementation of firebase user data