### PR TITLE
Fixed the problem of responses not being visible on the pollResults page, fixes issue #262 & #272

### DIFF
--- a/src/components/pollPopup.jsx
+++ b/src/components/pollPopup.jsx
@@ -39,7 +39,7 @@ export default function PollPopup(props){
     function handleClose(){
         props.set(false);
         setOpen(false);
-        props.setVoted(true);
+        // props.setVoted(true);
     }
 
     function handleClick(e){

--- a/src/pages/pollResults.jsx
+++ b/src/pages/pollResults.jsx
@@ -113,7 +113,8 @@ export default function PollResults(){
                 )}
                 <Box p={8} borderWidth="1px" borderRadius="lg">
                     <Heading as="h2" size="md" mb={4} align="center">Responses</Heading>
-                    { voted ? (
+
+                    {/* Responses */}
                         <Box>
                             {poll.type === 'multipleChoice' ?
                                 <Doughnut
@@ -133,9 +134,7 @@ export default function PollResults(){
                                 </Stack>
                             }
                         </Box>
-                    ) : (
-                        <Center>Responses will be visible once you submit your response</Center>
-                    ) }
+
                 </Box>
                 <Box borderWidth="1px" borderRadius="lg" h="40vh">
                     <Map defaultCenter={[poll.location._lat, poll.location._long]} defaultZoom={12} width="100%" height="100%" provider={getProvider}>

--- a/src/pages/profilePage.jsx
+++ b/src/pages/profilePage.jsx
@@ -52,7 +52,7 @@ export default function Profile(props) {
         if (!user) return;
 
         async function checkUserDoc() {
-            const userDatas = await getDoc('users', user.uid);
+            const userDatas = await getDoc('users', uid? uid : user.uid);
             if (!userDatas) {
                 await addDoc('users', {
                     displayName: "",
@@ -66,7 +66,7 @@ export default function Profile(props) {
         checkUserDoc();
 
         async function getPolls() {
-            const userDocs = await getUserDocs('polls', user.uid);
+            const userDocs = await getUserDocs('polls', uid? uid : user.uid);
             setPolls(userDocs);
             // setDisplayName(user.displayName ? user.displayName : "");
             setUserDoc(user)


### PR DESCRIPTION
## Description

Now users can see all the responses on the pollResults page and also users can submit their responses from the discover page itself.

Fixes #262 & #272 

## Type of change
Change in the implementation of the frontend code
